### PR TITLE
3주차 업데이트 및 1주차 수정

### DIFF
--- a/iOS/1주차/Delegate 패턴을 활용하는 경우를 예를 들어 설명하시오/PAKA/README.md
+++ b/iOS/1주차/Delegate 패턴을 활용하는 경우를 예를 들어 설명하시오/PAKA/README.md
@@ -1,1 +1,176 @@
 # Delegate 패턴을 활용하는 경우를 예를 들어 설명하시오.
+
+## Delegate 패턴이란?
+### 정의
+- Delegate의 사전적 의미 : 대리자, 대상에게 역할을 위임하다
+- 객체 지향 디자인 패턴으로서 코드의 재사용성이 증가하고 정보 은닉이 가능합니다.
+
+### 구현 방법
+- 객체의 역할을 먼저 구분한다.
+  - 데이터를 전달받고 싶은 객체는 delegate/receiver
+  - 데이터를 전달하게될 객체는 sender
+- sender 객체는 내부에 채택한 delegate프로토콜 타입의 변수(관습적으로 delegate라는 이름)를 가지고 객체 내부에 구현된 메서드에서 해당 delegate의 메서드를 호출합니다.
+
+```
+struct sender {
+  var delegate : ExDelegate? //보통 옵셔널로 선언
+  
+  var doSomething() {
+    delegate?.protocolImplementMethod() 
+    // 대리자가 존재한다면, 그 대리자가 구현해놓은 프로토콜 메서드를 호출
+  }
+}
+```
+</br>
+
+- receiver 객체는 sender 객체의 delegate가 자신임을 먼저 알려야 합니다. 또, sender에서 프로토콜 메서드를 사용할 수 있도록 프로토콜을 채택 후, 구현해줍니다.
+
+```
+struct receiver {
+
+ sender.delegate = self 
+// 국어 문법대로 이해하자. -> sender 객체의 대리자는 self(receiver객체)이다.
+
+}
+
+extension receiver : ExDelegate { 
+// 보통 가시성과 역할 분리를 위해 extension에서 프로토콜 채택 후 메서드를 구현해줍니다.
+
+  protocolImplementMethod() {
+    //구현
+  }
+}
+```
+
+### 
+
+## 예시(Swift 공식 가이드북)
+
+### 커스텀 프로토콜 정의
+
+- AnyObject는 모든 class가 사용 가능하도록 채택한다는 의미입니다.
+```
+protocol DiceGame {
+  var dice: Dice { get }
+  func play()
+}
+
+protocol DiceGameDelegate: AnyObject {
+  func gameDidStart(_ game: DiceGame)
+  func game(_ game: DiceGame, didStartNewTurnWithDiceRoll diceRoll: Int)
+  func gameDidEnd(_ game: DiceGame)
+}
+```
+
+### sender 객체 구현
+
+- 내부에 delegate 변수와 옵셔널 체이닝 형태로 프로토콜의 메서드를 호출하고 있습니다.
+
+```
+class SnakesAndLadders: DiceGame {
+  let finalSquare = 25
+  let dice = Dice(sides: 6, generator: LinearCongruentialGenerator())
+  var square = 0
+  var board: [Int]
+  init() {
+    board = Array(repeating: 0, count: finalSquare + 1)
+    board[03] = +08; board[06] = +11; board[09] = +09; board[10] = +02
+    board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
+  }
+  weak var delegate: DiceGameDelegate?
+  func play() {
+    square = 0
+    delegate?.gameDidStart(self)
+    gameLoop: while square != finalSquare {
+      let diceRoll = dice.roll()
+      delegate?.game(self, didStartNewTurnWithDiceRoll: diceRoll)
+      switch square + diceRoll {
+      case finalSquare:
+        break gameLoop
+      case let newSquare where newSquare > finalSquare:
+        continue gameLoop
+      default:
+        square += diceRoll
+        square += board[square]
+      }
+    }
+    delegate?.gameDidEnd(self)
+  }
+}
+```
+### receiver(delegate) 객체 구현
+
+
+- 커스텀 프로토콜을 채택해서 내부 메서드들을 구현해주고 있습니다.
+
+```
+class DiceGameTracker: DiceGameDelegate {
+  var numberOfTurns = 0
+  func gameDidStart(_ game: DiceGame) {
+    numberOfTurns = 0
+    if game is SnakesAndLadders {
+      print("Started a new game of Snakes and Ladders")
+    }
+    print("The game is using a \(game.dice.sides)-sided dice")
+  }
+  func game(_ game: DiceGame, didStartNewTurnWithDiceRoll diceRoll: Int) {
+    numberOfTurns += 1
+    print("Rolled a \(diceRoll)")
+  }
+  func gameDidEnd(_ game: DiceGame) {
+    print("The game lasted for \(numberOfTurns) turns")
+  }
+}
+```
+### 객체간의 연결!
+
+- 맥 앱을 통해 만들어진 코드이기 때문에 이렇게 특별히 외부에서 인스턴스를 두 개 생성 후 DiceGameTracker의 객체 tracker를 SnakesAndLadders의 객체 game의 대리자로 설정해주었습니다. 
+- 이를 통해 tracker의 play() 메서드가 호출되는 순간, 대리자인 game도 호출되어 구현한 메서드로 동작하게 됩니다. game이 tracker의 일을 대신해주는 셈이죠.
+
+```
+let tracker = DiceGameTracker()
+let game = SnakesAndLadders()
+game.delegate = tracker
+game.play()
+// Started a new game of Snakes and Ladders (새로운 뱀과 사다리 게임을 시작함)
+// The game is using a 6-sided dice (6-면체 주사위를 사용하는 게임임)
+// Rolled a 3 (3이 나옴)
+// Rolled a 5 (5가 나옴)
+// Rolled a 4 (4가 나옴)
+// Rolled a 5 (5가 나옴)
+// The game lasted for 4 turns (게임을 4턴 동안 지속함)
+```
+
+
+## UIKit 내부에서의 delegate 패턴 동작
+
+### 동작과정은 다르지 않다 (ex : textField)
+sender 객체(textField)와의 상호작용(터치, 값변경 등..) 
+
+ -> textField 객체 내부의 메서드에서 delegate변수의 옵셔널 체이닝을 통해 TextFieldDelegate프로토콜 메서드 호출
+
+ -> delegate(receiver)로 설정되어 있는 객체(주로 viewController)가 호출됨. 해당 객체는 TextFieldDelegate를 채택하여 이런 호출을 받았을 때 어떤 동작을 할지 구현해놓았음.
+
+ -> textField의 value값 길이 제한, 숫자 입력 금지, 전체 삭제 활성화 등 다양한 동작 가능..  
+
+### 허나.. 한가지 다른 점
+
+- sender에서 delegate를 호출하는 코드는 사실 definition에 들어가도 볼 수 없다!
+- 왜? 애플의 기업비밀...
+
+```
+class UITextField {
+  ...
+  func callDelegate() { // 실제이름은 callDelegate가 아닐것이다.
+    ...
+      delegate?.프로토콜메서드() 
+  }
+
+}
+```
+
+## 참고 자료 및  읽을거리
+
+### [애플 공식문서](https://developer.apple.com/documentation/swift/using-delegates-to-customize-object-behavior)
+
+### [Swift 공식 가이드북 번역- protocol부분](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID278)

--- a/iOS/3주차/instance 메서드와 class 메서드의 차이점을 설명하시오/PAKA/README.md
+++ b/iOS/3주차/instance 메서드와 class 메서드의 차이점을 설명하시오/PAKA/README.md
@@ -70,5 +70,7 @@ SomeClass.someTypeMethod()
 
 ## 참고 자료 및  읽을거리
 
-### [static 메서드는 언제 사용할까](https://sujinnaljin.medium.com/swift-static%EA%B3%BC-class-method-property-%ED%9A%A8%EA%B3%BC%EC%A0%81%EC%9C%BC%EB%A1%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0-b336311a923c)
+### [인스턴스 메서드와 타입 메서드의 차이? (스택오버플로우)](https://stackoverflow.com/questions/28551953/the-difference-between-swifts-instance-methods-and-type-methods)
+
+### [타입 메서드는 언제 사용할까](https://sujinnaljin.medium.com/swift-static%EA%B3%BC-class-method-property-%ED%9A%A8%EA%B3%BC%EC%A0%81%EC%9C%BC%EB%A1%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0-b336311a923c)
 ### [swift 공식 가이드북 한글 번역 - 메서드](https://xho95.github.io/swift/language/grammar/method/2020/05/03/Methods.html)

--- a/iOS/3주차/instance 메서드와 class 메서드의 차이점을 설명하시오/PAKA/README.md
+++ b/iOS/3주차/instance 메서드와 class 메서드의 차이점을 설명하시오/PAKA/README.md
@@ -1,1 +1,74 @@
 # instance 메서드와 class 메서드의 차이점을 설명하시오.
+
+## 메서드란?
+### 정의
+- 인스턴스(구조체, 클래스) 내부에 구현된 함수로, 원하는 동작을 정의할 수 있다.
+- 메모리 공간이 할당되어 있지 않다.(함수의 특성, 필요한 시점에 스택에 호출되었다 실행후 소멸)
+
+### 종류
+- 생성자, 서브스크립트, 인스턴스 메서드, 타입 메서드. 
+- 사실상 메서드이나 속성인 계산 속성도 존재
+
+### 
+
+## instance 메서드?
+
+### 정의
+```
+class Example {
+  var ex1 : Int = -1
+  var ex2 : Int = 1
+  func instanceMethod() {
+  print("\(ex1) + \(ex2) = \(ex1+ex2)")
+  }
+}
+```
+- 위치만 클래스나 구조체 내부에 있을 뿐, 형태는 함수와 동일
+
+### 특징
+
+- 메서드에 접근하려면 인스턴스 명으로 접근해야 한다.
+
+
+```
+var instance1 = Example()
+instance1.instanceMethod() // 0
+```
+- 클래스 제외 mutating 키워드 없이는 내부 속성을 변경할 수 없다. 또, 인스턴스가 상수로 선언되었다면, mutating 키워드가 있더라도 내부 속성을 변경할 수 없다.
+
+```
+struct cons {
+  var attribute1 : String?
+  var attribute2 : Int?
+
+  mutating func changeAttribute2(variable : Int?) {
+      self.attribute2  = variable  
+  }
+}
+
+var changed = cons()
+changed.changeAttribute2(variable : 3) // attribute2 = 3
+let immutable = cons()
+changed.changeAttribute2(variable : 4) // 컴파일러가 에러를 표시함.
+```
+
+## 타입(static, class) 메서드는?
+
+### 특징
+- 생성된 인스턴스가 아닌 타입에 귀속된 메서드로서 사용시 해당 타입명으로 호출한다.
+`Int.random(in:1...100) `
+- 메서드 앞에 static 키워드를 붙이는게 일반적이고 클래스의 경우 class 키워드를 붙인다.
+
+```
+class SomeClass {
+  class func someTypeMethod() {
+    // 타입 메소드 구현은 여기에 둠
+  }
+}
+SomeClass.someTypeMethod()
+```
+
+## 참고 자료 및  읽을거리
+
+### [static 메서드는 언제 사용할까](https://sujinnaljin.medium.com/swift-static%EA%B3%BC-class-method-property-%ED%9A%A8%EA%B3%BC%EC%A0%81%EC%9C%BC%EB%A1%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0-b336311a923c)
+### [swift 공식 가이드북 한글 번역 - 메서드](https://xho95.github.io/swift/language/grammar/method/2020/05/03/Methods.html)


### PR DESCRIPTION
## 3주차 내용 업데이트(instance 메서드와 class 메서드의 차이)

## 1주차 내용 정정 및 마크다운 양식으로 변경
- 참고했던 블로그의 내용이 틀려 정정하여 다시 작성하였습니다.
- receiver와 delegate는 사실 같은 개념이며, sender와 receiver(delegate)로 역할이 나뉘어집니다.
- 예를 들어, ``객체A.delegate = 객체B``라는 코드는 객체A의 대리자는 객체B의 대리자라는 의미가 맞습니다!
